### PR TITLE
Update the link to point to the new documentation

### DIFF
--- a/0.1/index.html
+++ b/0.1/index.html
@@ -33,8 +33,8 @@
         <li class="left-navheader">Pages</li>
 
 <li><a href="manual/html/manual.html">manual (html)</a></li>
-<li><a href="manual/manual.pdf">manual (pdf)</a></li>
 <li><a href="install/index.html">installation</a></li>
+<li><a href="manual/manual.pdf">manual (pdf)</a></li>
 
 
 
@@ -255,7 +255,7 @@ Physical Sciences Research Council (EPSRC)</a> (United Kingdom).
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../rest2web.html">rest2web</a>, and <a href="../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.1/install/debian.html
+++ b/0.1/install/debian.html
@@ -32,9 +32,9 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
-<li><a href="vmplayer.html">Virtual Machine</a></li>
 <li><a href="knoppix.html">Knoppix CD</a></li>
 <li><a href="debian.html">Debian package</a></li>
+<li><a href="vmplayer.html">Virtual Machine</a></li>
 
 
 
@@ -67,25 +67,25 @@
       <div class="document" id="installing-nmag-on-a-debian-based-linux-system">
 <h1 class="title">Installing nmag on a debian based Linux system</h1>
 <div class="contents topic" id="contents">
-<p class="topic-title first">Contents</p>
+<p class="topic-title">Contents</p>
 <ul class="simple">
-<li><a class="reference internal" href="#generic-instructions" id="id1">Generic instructions</a><ul>
-<li><a class="reference internal" href="#install-outdate-version-as-debian-package" id="id2">Install outdate version as debian package</a></li>
-<li><a class="reference internal" href="#for-debian-experts" id="id3">For Debian experts</a></li>
+<li><a class="reference internal" href="#generic-instructions" id="toc-entry-1">Generic instructions</a><ul>
+<li><a class="reference internal" href="#install-outdate-version-as-debian-package" id="toc-entry-2">Install outdate version as debian package</a></li>
+<li><a class="reference internal" href="#for-debian-experts" id="toc-entry-3">For Debian experts</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#notes-for-ubuntu" id="id4">Notes for Ubuntu</a></li>
-<li><a class="reference internal" href="#installing-netgen" id="id5">Installing Netgen</a></li>
+<li><a class="reference internal" href="#notes-for-ubuntu" id="toc-entry-4">Notes for Ubuntu</a></li>
+<li><a class="reference internal" href="#installing-netgen" id="toc-entry-5">Installing Netgen</a></li>
 </ul>
 </div>
 <div class="section" id="generic-instructions">
-<h1><a class="toc-backref" href="#id1">Generic instructions</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">Generic instructions</a></h1>
 <p>We only support Debian etch with the 6163 release from 30 March 2009
 release. To install Nmag on Debian Lenny (or unstable or testing), or
 <em>to use the latest Nmag release, please use the</em> <a class="reference external" href="install_a.html">compile-from-source
 version</a>.</p>
 <div class="section" id="install-outdate-version-as-debian-package">
-<h2><a class="toc-backref" href="#id2">Install outdate version as debian package</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-2">Install outdate version as debian package</a></h2>
 <p>Add the following line to <tt class="docutils literal">/etc/apt/sources.list</tt>:</p>
 <pre class="literal-block">
 deb http://nmag.soton.ac.uk/debian/ stable unofficial
@@ -106,7 +106,7 @@ $ aptitude install nsim</blockquote>
 <p>to install nsim. This will automatically install all required dependencies.</p>
 </div>
 <div class="section" id="for-debian-experts">
-<h2><a class="toc-backref" href="#id3">For Debian experts</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">For Debian experts</a></h2>
 <p>Nsim can be obtained directly from
 <a class="reference external" href="http://nmag.soton.ac.uk/debian/dists/stable/unofficial/binary-i386/">http://nmag.soton.ac.uk/debian/dists/stable/unofficial/binary-i386/</a>
 and installed manually (using <tt class="docutils literal">dpkg <span class="pre">-i</span> [packagefile.deb]</tt>). However,
@@ -114,7 +114,7 @@ one needs to fulfill all requirements manually.</p>
 </div>
 </div>
 <div class="section" id="notes-for-ubuntu">
-<h1><a class="toc-backref" href="#id4">Notes for Ubuntu</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Notes for Ubuntu</a></h1>
 <p>Please install by <a class="reference external" href="install_a.html">compiling from source</a>.</p>
 <!-- comment:
 
@@ -168,7 +168,7 @@ most recent developer debian package by using the following line instead::
 (Strictly speaking, this works but violates RFC1738.) -->
 </div>
 <div class="section" id="installing-netgen">
-<h1><a class="toc-backref" href="#id5">Installing Netgen</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Installing Netgen</a></h1>
 <p>Netgen is available for debian in the 'unstable' version. To get
 access to this (from etch, which is the current 'stable' version),
 follow these instructions:</p>
@@ -229,7 +229,7 @@ $&gt; aptitude update
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../../rest2web.html">rest2web</a>, and <a href="../../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.1/install/index.html
+++ b/0.1/install/index.html
@@ -32,9 +32,9 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
-<li><a href="vmplayer.html">Virtual Machine</a></li>
 <li><a href="knoppix.html">Knoppix CD</a></li>
 <li><a href="debian.html">Debian package</a></li>
+<li><a href="vmplayer.html">Virtual Machine</a></li>
 
 
 
@@ -65,29 +65,29 @@
       <div class="document" id="installation-methods">
 <h1 class="title">Installation methods</h1>
 <div class="contents topic" id="contents">
-<p class="topic-title first">Contents</p>
+<p class="topic-title">Contents</p>
 <ul class="auto-toc simple">
-<li><a class="reference internal" href="#how-can-i-install-nmag-for-windows-linux-mac-osx" id="id1">1&nbsp;&nbsp;&nbsp;How can I install nmag for Windows/Linux/Mac OSX?</a><ul class="auto-toc">
-<li><a class="reference internal" href="#mac-os-x" id="id2">1.1&nbsp;&nbsp;&nbsp;Mac OS X</a></li>
-<li><a class="reference internal" href="#debian-linux-ubuntu-knoppix-and-other-debian-derivatives" id="id3">1.2&nbsp;&nbsp;&nbsp;Debian Linux, Ubuntu, Knoppix and other debian derivatives</a></li>
-<li><a class="reference internal" href="#linux-unix-in-general" id="id4">1.3&nbsp;&nbsp;&nbsp;Linux/UNIX in general</a></li>
-<li><a class="reference internal" href="#windows" id="id5">1.4&nbsp;&nbsp;&nbsp;Windows</a></li>
+<li><a class="reference internal" href="#how-can-i-install-nmag-for-windows-linux-mac-osx" id="toc-entry-1">1&nbsp;&nbsp;&nbsp;How can I install nmag for Windows/Linux/Mac OSX?</a><ul class="auto-toc">
+<li><a class="reference internal" href="#mac-os-x" id="toc-entry-2">1.1&nbsp;&nbsp;&nbsp;Mac OS X</a></li>
+<li><a class="reference internal" href="#debian-linux-ubuntu-knoppix-and-other-debian-derivatives" id="toc-entry-3">1.2&nbsp;&nbsp;&nbsp;Debian Linux, Ubuntu, Knoppix and other debian derivatives</a></li>
+<li><a class="reference internal" href="#linux-unix-in-general" id="toc-entry-4">1.3&nbsp;&nbsp;&nbsp;Linux/UNIX in general</a></li>
+<li><a class="reference internal" href="#windows" id="toc-entry-5">1.4&nbsp;&nbsp;&nbsp;Windows</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#what-installation-methods-are-provided" id="id6">2&nbsp;&nbsp;&nbsp;What installation methods are provided?</a><ul class="auto-toc">
-<li><a class="reference internal" href="#method-a-compile-everything-from-source" id="id7">2.1&nbsp;&nbsp;&nbsp;Method A: compile everything from source</a></li>
-<li><a class="reference internal" href="#method-b-debian-package" id="id8">2.2&nbsp;&nbsp;&nbsp;Method B: Debian package</a></li>
-<li><a class="reference internal" href="#method-c-knoppix-cd" id="id9">2.3&nbsp;&nbsp;&nbsp;Method C: Knoppix CD</a></li>
-<li><a class="reference internal" href="#method-d-virtual-appliance" id="id10">2.4&nbsp;&nbsp;&nbsp;Method D: Virtual Appliance</a></li>
+<li><a class="reference internal" href="#what-installation-methods-are-provided" id="toc-entry-6">2&nbsp;&nbsp;&nbsp;What installation methods are provided?</a><ul class="auto-toc">
+<li><a class="reference internal" href="#method-a-compile-everything-from-source" id="toc-entry-7">2.1&nbsp;&nbsp;&nbsp;Method A: compile everything from source</a></li>
+<li><a class="reference internal" href="#method-b-debian-package" id="toc-entry-8">2.2&nbsp;&nbsp;&nbsp;Method B: Debian package</a></li>
+<li><a class="reference internal" href="#method-c-knoppix-cd" id="toc-entry-9">2.3&nbsp;&nbsp;&nbsp;Method C: Knoppix CD</a></li>
+<li><a class="reference internal" href="#method-d-virtual-appliance" id="toc-entry-10">2.4&nbsp;&nbsp;&nbsp;Method D: Virtual Appliance</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#abbreviations-used" id="id11">3&nbsp;&nbsp;&nbsp;Abbreviations used</a></li>
+<li><a class="reference internal" href="#abbreviations-used" id="toc-entry-11">3&nbsp;&nbsp;&nbsp;Abbreviations used</a></li>
 </ul>
 </div>
 <div class="section" id="how-can-i-install-nmag-for-windows-linux-mac-osx">
-<h1><a class="toc-backref" href="#id1">1&nbsp;&nbsp;&nbsp;How can I install nmag for Windows/Linux/Mac OSX?</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">1&nbsp;&nbsp;&nbsp;How can I install nmag for Windows/Linux/Mac OSX?</a></h1>
 <div class="section" id="mac-os-x">
-<h2><a class="toc-backref" href="#id2">1.1&nbsp;&nbsp;&nbsp;Mac OS X</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-2">1.1&nbsp;&nbsp;&nbsp;Mac OS X</a></h2>
 <p>You can compile nmag and required helping libraries from source
 (<a class="reference external" href="../download/nmag-0.1-all.tar.gz">download tar file</a>, <a class="reference external" href="install_a.html">Method A
 installation instructions</a>).</p>
@@ -95,20 +95,20 @@ installation instructions</a>).</p>
 <a class="reference external" href="vmplayer.html">Method D</a>).</p>
 </div>
 <div class="section" id="debian-linux-ubuntu-knoppix-and-other-debian-derivatives">
-<h2><a class="toc-backref" href="#id3">1.2&nbsp;&nbsp;&nbsp;Debian Linux, Ubuntu, Knoppix and other debian derivatives</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">1.2&nbsp;&nbsp;&nbsp;Debian Linux, Ubuntu, Knoppix and other debian derivatives</a></h2>
 <p>Please <a class="reference external" href="install_a.html">compile from source</a>.</p>
 <p>There is a debian package available for the Nmag release 6131 from March 2009 (see <a class="reference external" href="debian.html">Debian package installation instructions</a>).</p>
 <p>You can also use the Nmag Virtual Machine (<a class="reference external" href="vmplayer.html">Method D</a>).</p>
 </div>
 <div class="section" id="linux-unix-in-general">
-<h2><a class="toc-backref" href="#id4">1.3&nbsp;&nbsp;&nbsp;Linux/UNIX in general</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">1.3&nbsp;&nbsp;&nbsp;Linux/UNIX in general</a></h2>
 <p>You can compile nmag and required helping libraries from source
 (<a class="reference external" href="../download/nmag-0.1-all.tar.gz">download tar file</a>, <a class="reference external" href="install_a.html">Method A
 installation instructions</a>)</p>
 <p>You can also use the Nmag Virtual Machine (<a class="reference external" href="vmplayer.html">Method D</a>).</p>
 </div>
 <div class="section" id="windows">
-<h2><a class="toc-backref" href="#id5">1.4&nbsp;&nbsp;&nbsp;Windows</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">1.4&nbsp;&nbsp;&nbsp;Windows</a></h2>
 <p>There is currently no nmag version for Windows. You have two options
 of running nmag:</p>
 <ol class="arabic">
@@ -130,13 +130,13 @@ few examples from the tutorial.</p>
 </div>
 <hr class="docutils" />
 <div class="section" id="what-installation-methods-are-provided">
-<h1><a class="toc-backref" href="#id6">2&nbsp;&nbsp;&nbsp;What installation methods are provided?</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-6">2&nbsp;&nbsp;&nbsp;What installation methods are provided?</a></h1>
 <p>This section repeats information listed above under <a class="reference internal" href="#how-can-i-install-nmag-for-windows-linux-mac-osx">How can I install
 nmag for Windows/Linux/Mac OSX?</a>. Here, it is not ordered according
 to the operating system you are interested in, but lists the different
 installation methods that are provided.</p>
 <div class="section" id="method-a-compile-everything-from-source">
-<h2><a class="toc-backref" href="#id7">2.1&nbsp;&nbsp;&nbsp;Method A: compile everything from source</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">2.1&nbsp;&nbsp;&nbsp;Method A: compile everything from source</a></h2>
 <p>Download a large archive that provides nmag together with (nearly) all
 required tools, and compile everything from source. Compile time is
 between 15 minutes and one hour, disk space required about 1 GB.</p>
@@ -156,7 +156,7 @@ between 15 minutes and one hour, disk space required about 1 GB.</p>
 </table>
 </div>
 <div class="section" id="method-b-debian-package">
-<h2><a class="toc-backref" href="#id8">2.2&nbsp;&nbsp;&nbsp;Method B: Debian package</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">2.2&nbsp;&nbsp;&nbsp;Method B: Debian package</a></h2>
 <p>A debian package is provided. This is very convenient if you happen to
 run a debian (etch) distribution, or linux distributions that are
 derived from Debian (such as Ubuntu).</p>
@@ -176,7 +176,7 @@ derived from Debian (such as Ubuntu).</p>
 </table>
 </div>
 <div class="section" id="method-c-knoppix-cd">
-<h2><a class="toc-backref" href="#id9">2.3&nbsp;&nbsp;&nbsp;Method C: Knoppix CD</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">2.3&nbsp;&nbsp;&nbsp;Method C: Knoppix CD</a></h2>
 <p>An CD iso image is provided which can be burnt to an CD. Any i386
 machine can use this CD to boot from. This will boot into a special
 Linux distribution (<em>Knoppix</em>) which has nmag installed. This process
@@ -198,7 +198,7 @@ evaluate Nmag quickly without needing any disk space.</p>
 </table>
 </div>
 <div class="section" id="method-d-virtual-appliance">
-<h2><a class="toc-backref" href="#id10">2.4&nbsp;&nbsp;&nbsp;Method D: Virtual Appliance</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10">2.4&nbsp;&nbsp;&nbsp;Method D: Virtual Appliance</a></h2>
 <p>A <em>Virtual appliance</em> (also called virtual machine) is provided that
 provides a (Debian etch) Linux environment, including nmag, a mesh
 generactor (Netgen) and many post-processing tools (MayaVi, Gnuplot,
@@ -236,7 +236,7 @@ mechanism.</li>
 </div>
 <hr class="docutils" />
 <div class="section" id="abbreviations-used">
-<h1><a class="toc-backref" href="#id11">3&nbsp;&nbsp;&nbsp;Abbreviations used</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-11">3&nbsp;&nbsp;&nbsp;Abbreviations used</a></h1>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -276,7 +276,7 @@ different.</p>
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../../rest2web.html">rest2web</a>, and <a href="../../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.1/install/knoppix.html
+++ b/0.1/install/knoppix.html
@@ -32,9 +32,9 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
-<li><a href="vmplayer.html">Virtual Machine</a></li>
 <li><a href="knoppix.html">Knoppix CD</a></li>
 <li><a href="debian.html">Debian package</a></li>
+<li><a href="vmplayer.html">Virtual Machine</a></li>
 
 
 
@@ -104,7 +104,7 @@ by default, never uses the hard drive).</p>
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../../rest2web.html">rest2web</a>, and <a href="../../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.1/install/vmplayer.html
+++ b/0.1/install/vmplayer.html
@@ -32,9 +32,9 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
-<li><a href="vmplayer.html">Virtual Machine</a></li>
 <li><a href="knoppix.html">Knoppix CD</a></li>
 <li><a href="debian.html">Debian package</a></li>
+<li><a href="vmplayer.html">Virtual Machine</a></li>
 
 
 
@@ -67,25 +67,25 @@
       <div class="document" id="installing-nmag-using-the-vmware-player">
 <h1 class="title">Installing Nmag using the VMware Player</h1>
 <div class="contents topic" id="contents">
-<p class="topic-title first">Contents</p>
+<p class="topic-title">Contents</p>
 <ul class="simple">
-<li><a class="reference internal" href="#introduction" id="id2">Introduction</a></li>
-<li><a class="reference internal" href="#installing-the-vmware-player" id="id3">Installing the VMware Player</a></li>
-<li><a class="reference internal" href="#downloading-and-starting-the-nmag-virtual-machine" id="id4">Downloading and starting the Nmag virtual machine</a></li>
-<li><a class="reference internal" href="#using-the-nmag-virtual-machine" id="id5">Using the Nmag virtual machine</a></li>
-<li><a class="reference internal" href="#first-steps" id="id6">First steps</a></li>
-<li><a class="reference internal" href="#using-vmware-player" id="id7">Using VMware player</a></li>
-<li><a class="reference internal" href="#frequently-asked-questions" id="id8">Frequently Asked Questions</a><ul>
-<li><a class="reference internal" href="#how-can-i-exchange-data-between-the-virtual-machine-and-the-host" id="id9">How can I exchange data between the virtual machine and the host?</a></li>
-<li><a class="reference internal" href="#how-can-i-change-the-keyboard-in-the-nmag-virtual-machine" id="id10">How can I change the keyboard in the Nmag virtual machine?</a></li>
-<li><a class="reference internal" href="#can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine" id="id11">Can I also use other VMware products with the Nmag Virtual machine?</a></li>
-<li><a class="reference internal" href="#i-know-debian-linux-can-i-modify-this-system" id="id12">I know Debian Linux -- can I modify this system?</a></li>
+<li><a class="reference internal" href="#introduction" id="toc-entry-1">Introduction</a></li>
+<li><a class="reference internal" href="#installing-the-vmware-player" id="toc-entry-2">Installing the VMware Player</a></li>
+<li><a class="reference internal" href="#downloading-and-starting-the-nmag-virtual-machine" id="toc-entry-3">Downloading and starting the Nmag virtual machine</a></li>
+<li><a class="reference internal" href="#using-the-nmag-virtual-machine" id="toc-entry-4">Using the Nmag virtual machine</a></li>
+<li><a class="reference internal" href="#first-steps" id="toc-entry-5">First steps</a></li>
+<li><a class="reference internal" href="#using-vmware-player" id="toc-entry-6">Using VMware player</a></li>
+<li><a class="reference internal" href="#frequently-asked-questions" id="toc-entry-7">Frequently Asked Questions</a><ul>
+<li><a class="reference internal" href="#how-can-i-exchange-data-between-the-virtual-machine-and-the-host" id="toc-entry-8">How can I exchange data between the virtual machine and the host?</a></li>
+<li><a class="reference internal" href="#how-can-i-change-the-keyboard-in-the-nmag-virtual-machine" id="toc-entry-9">How can I change the keyboard in the Nmag virtual machine?</a></li>
+<li><a class="reference internal" href="#can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine" id="toc-entry-10">Can I also use other VMware products with the Nmag Virtual machine?</a></li>
+<li><a class="reference internal" href="#i-know-debian-linux-can-i-modify-this-system" id="toc-entry-11">I know Debian Linux -- can I modify this system?</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="introduction">
-<h1><a class="toc-backref" href="#id2">Introduction</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">Introduction</a></h1>
 <p><a class="reference external" href="http://www.vmware.com">VMware</a> is a company that provides a software that emulates a virtual
 computer. Let's assume for simplicity that we have an existing machine
 with MS Windows. This is called the host machine. One needs to install
@@ -118,7 +118,7 @@ RAM (the more the better). It currently needs about 5GB of disk space
 on the host machine.</p>
 </div>
 <div class="section" id="installing-the-vmware-player">
-<h1><a class="toc-backref" href="#id3">Installing the VMware Player</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Installing the VMware Player</a></h1>
 <p><a class="reference external" href="http://www.vmware.com">VMware</a> provides a multitude of different products that allow
 different degrees of virtualisation. Some of them are free and some
 have to be paid for. We try to point to exactly the right product
@@ -170,7 +170,7 @@ Machine method.</p>
 obtain the 'virtual machine' that we want to execute.</p>
 </div>
 <div class="section" id="downloading-and-starting-the-nmag-virtual-machine">
-<h1><a class="toc-backref" href="#id4">Downloading and starting the Nmag virtual machine</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Downloading and starting the Nmag virtual machine</a></h1>
 <ul class="simple">
 <li>Download the zipped Nmag virtual appliance from <a class="reference external" href="http://nmag.soton.ac.uk/vmware/0.1">this directory</a>. The appliance is split into two files (to ensure that each file does not exceed the 2GB file size limit that some file systems impose).</li>
 <li>unzip the downloaded files: extract they content into a subdirectory with name <tt class="docutils literal"><span class="pre">nmag-0.1</span></tt>.</li>
@@ -191,7 +191,7 @@ obtain the 'virtual machine' that we want to execute.</p>
 <p>Wait until the graphical login turns up.</p>
 </div>
 <div class="section" id="using-the-nmag-virtual-machine">
-<h1><a class="toc-backref" href="#id5">Using the Nmag virtual machine</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Using the Nmag virtual machine</a></h1>
 <p>The Nmag virtual machine is a Debian Linux (Lenny) installation which provides
 all the software required to run micromagnetic simulations with Nmag.</p>
 <p>After booting, a login screen appears. There is only one user
@@ -211,7 +211,7 @@ of plots in the manual, and for automatic testing (you may want to
 ignore those). There is a shortcut <tt class="docutils literal">manual</tt> for this directory on the Desktop, and also in the home directory of the nmag user.</p>
 </div>
 <div class="section" id="first-steps">
-<h1><a class="toc-backref" href="#id6">First steps</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">First steps</a></h1>
 <ol class="arabic">
 <li><p class="first">Login as <tt class="docutils literal">nmag</tt>, password <tt class="docutils literal">nmag</tt>.</p>
 </li>
@@ -239,7 +239,7 @@ nsim sphere1.py
 </ol>
 </div>
 <div class="section" id="using-vmware-player">
-<h1><a class="toc-backref" href="#id7">Using VMware player</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-6">Using VMware player</a></h1>
 <p>The help function of the VMware Player provides a useful summary of
 how to use it.</p>
 <p>Note that you can switch to full-screen mode when pressing
@@ -248,17 +248,17 @@ pressing CTRL+ALT, or moving the mouse to the top of the screen (to
 get the VMPlayer menu).</p>
 </div>
 <div class="section" id="frequently-asked-questions">
-<h1><a class="toc-backref" href="#id8">Frequently Asked Questions</a></h1>
-<div class="contents local topic" id="id1">
+<h1><a class="toc-backref" href="#toc-entry-7">Frequently Asked Questions</a></h1>
+<div class="contents local topic" id="topic-1">
 <ul class="simple">
-<li><a class="reference internal" href="#how-can-i-exchange-data-between-the-virtual-machine-and-the-host" id="id13">How can I exchange data between the virtual machine and the host?</a></li>
-<li><a class="reference internal" href="#how-can-i-change-the-keyboard-in-the-nmag-virtual-machine" id="id14">How can I change the keyboard in the Nmag virtual machine?</a></li>
-<li><a class="reference internal" href="#can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine" id="id15">Can I also use other VMware products with the Nmag Virtual machine?</a></li>
-<li><a class="reference internal" href="#i-know-debian-linux-can-i-modify-this-system" id="id16">I know Debian Linux -- can I modify this system?</a></li>
+<li><a class="reference internal" href="#how-can-i-exchange-data-between-the-virtual-machine-and-the-host" id="toc-entry-12">How can I exchange data between the virtual machine and the host?</a></li>
+<li><a class="reference internal" href="#how-can-i-change-the-keyboard-in-the-nmag-virtual-machine" id="toc-entry-13">How can I change the keyboard in the Nmag virtual machine?</a></li>
+<li><a class="reference internal" href="#can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine" id="toc-entry-14">Can I also use other VMware products with the Nmag Virtual machine?</a></li>
+<li><a class="reference internal" href="#i-know-debian-linux-can-i-modify-this-system" id="toc-entry-15">I know Debian Linux -- can I modify this system?</a></li>
 </ul>
 </div>
 <div class="section" id="how-can-i-exchange-data-between-the-virtual-machine-and-the-host">
-<h2><a class="toc-backref" href="#id13">How can I exchange data between the virtual machine and the host?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-12">How can I exchange data between the virtual machine and the host?</a></h2>
 <p>If you want to share data with your host, then</p>
 <ul>
 <li><p class="first">go to <tt class="docutils literal">VMWare <span class="pre">Player-&gt;Preferences-&gt;Shared</span> Folders</tt>.</p>
@@ -278,18 +278,18 @@ example your Desktop (or a dedicated subfolder somewhere).</p>
 </ul>
 </div>
 <div class="section" id="how-can-i-change-the-keyboard-in-the-nmag-virtual-machine">
-<h2><a class="toc-backref" href="#id14">How can I change the keyboard in the Nmag virtual machine?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-13">How can I change the keyboard in the Nmag virtual machine?</a></h2>
 <p>Log in, then go to System-&gt;Preferences-&gt;Keyboard-&gt;Layouts.</p>
 </div>
 <div class="section" id="can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine">
-<h2><a class="toc-backref" href="#id15">Can I also use other VMware products with the Nmag Virtual machine?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-14">Can I also use other VMware products with the Nmag Virtual machine?</a></h2>
 <p>Yes, as far as we know. For example, if you have the VMware Work
 station or VMware Server, then these can run the Nmag virtual machine
 as well. (It may, in fact, be easier to exchange data between the host
 and the virtual machine with these more powerful products.)</p>
 </div>
 <div class="section" id="i-know-debian-linux-can-i-modify-this-system">
-<h2><a class="toc-backref" href="#id16">I know Debian Linux -- can I modify this system?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-15">I know Debian Linux -- can I modify this system?</a></h2>
 <p>Of course. Once you become root, you can use <tt class="docutils literal">aptitude</tt> and all
 other tools to configure your debian system. This is, after all, a
 normal installation (even though it is executed within a virtual
@@ -317,7 +317,7 @@ machine).</p>
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../../rest2web.html">rest2web</a>, and <a href="../../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.1/olderchangelog.html
+++ b/0.1/olderchangelog.html
@@ -33,8 +33,8 @@
         <li class="left-navheader">Pages</li>
 
 <li><a href="manual/html/manual.html">manual (html)</a></li>
-<li><a href="manual/manual.pdf">manual (pdf)</a></li>
 <li><a href="install/index.html">installation</a></li>
+<li><a href="manual/manual.pdf">manual (pdf)</a></li>
 
 
 
@@ -314,13 +314,13 @@ detection fails.</li>
 </li>
 </ul>
 </div>
-<div class="section" id="id1">
+<div class="section" id="release-0-1-beta-5274-3-february-2008-1">
 <h1>Release 0.1 beta (5274) 3 February 2008</h1>
 <ul class="simple">
 <li>As 0.1 beta (5259) but with working debian package.</li>
 </ul>
 </div>
-<div class="section" id="id2">
+<div class="section" id="release-0-1-beta-5259-30-january-2008-1">
 <h1>Release 0.1 beta (5259) 30 January 2008</h1>
 <ul>
 <li><p class="first">Bug fixes/Improvements</p>
@@ -346,7 +346,7 @@ nsim-core is not sufficient).</li>
 </ul>
 <p>Note: there is no debian package for this release.</p>
 </div>
-<div class="section" id="id3">
+<div class="section" id="release-0-1-beta-4947-20-december-2007-1">
 <h1>Release 0.1 beta (4947) 20 December 2007</h1>
 <ul>
 <li><p class="first">Bug fixes/Improvements</p>
@@ -420,7 +420,7 @@ documentation</li>
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../rest2web.html">rest2web</a>, and <a href="../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.1/upgrade.html
+++ b/0.1/upgrade.html
@@ -33,8 +33,8 @@
         <li class="left-navheader">Pages</li>
 
 <li><a href="manual/html/manual.html">manual (html)</a></li>
-<li><a href="manual/manual.pdf">manual (pdf)</a></li>
 <li><a href="install/index.html">installation</a></li>
+<li><a href="manual/manual.pdf">manual (pdf)</a></li>
 
 
 
@@ -65,21 +65,21 @@
       <div class="document" id="how-to-upgrade-nmag">
 <h1 class="title">How to upgrade Nmag</h1>
 <div class="contents topic" id="overview">
-<p class="topic-title first">Overview</p>
+<p class="topic-title">Overview</p>
 <ul class="simple">
-<li><a class="reference internal" href="#introduction" id="id1">Introduction</a></li>
-<li><a class="reference internal" href="#method-a-compile-everything-from-source" id="id2">Method A: compile everything from source</a></li>
-<li><a class="reference internal" href="#method-b-debian-package" id="id3">Method B: Debian package</a></li>
-<li><a class="reference internal" href="#method-c-knoppix-cd" id="id4">Method C: Knoppix CD</a></li>
-<li><a class="reference internal" href="#method-d-nmag-virtual-machine" id="id5">Method D: Nmag Virtual Machine</a></li>
+<li><a class="reference internal" href="#introduction" id="toc-entry-1">Introduction</a></li>
+<li><a class="reference internal" href="#method-a-compile-everything-from-source" id="toc-entry-2">Method A: compile everything from source</a></li>
+<li><a class="reference internal" href="#method-b-debian-package" id="toc-entry-3">Method B: Debian package</a></li>
+<li><a class="reference internal" href="#method-c-knoppix-cd" id="toc-entry-4">Method C: Knoppix CD</a></li>
+<li><a class="reference internal" href="#method-d-nmag-virtual-machine" id="toc-entry-5">Method D: Nmag Virtual Machine</a></li>
 </ul>
 </div>
 <div class="section" id="introduction">
-<h1><a class="toc-backref" href="#id1">Introduction</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">Introduction</a></h1>
 <p>How to upgrade Nmag depends on the way it which it has been installed.</p>
 </div>
 <div class="section" id="method-a-compile-everything-from-source">
-<h1><a class="toc-backref" href="#id2">Method A: compile everything from source</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Method A: compile everything from source</a></h1>
 <p>If you have compiled Nmag <a class="reference external" href="install/install_a.html">from source</a>, you have two options:</p>
 <ul>
 <li><p class="first">optionally move the old installation directory (<tt class="docutils literal"><span class="pre">nmag-0.1</span></tt>) to a
@@ -169,7 +169,7 @@ for this quick check).</p>
 </ol>
 </div>
 <div class="section" id="method-b-debian-package">
-<h1><a class="toc-backref" href="#id3">Method B: Debian package</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Method B: Debian package</a></h1>
 <p>If you are running Debian (or a derived distribution such as Ubuntu or
 Knoppix), you shoud be able to upgrade the <tt class="docutils literal">nsim</tt> package:</p>
 <ul>
@@ -199,13 +199,13 @@ $&gt; aptitude install nsim
 </ol>
 </div>
 <div class="section" id="method-c-knoppix-cd">
-<h1><a class="toc-backref" href="#id4">Method C: Knoppix CD</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Method C: Knoppix CD</a></h1>
 <p>The Knoppix distribution is Debian based, so you can follow the
 instructions for <a class="reference internal" href="#method-b-debian-package">Method B: Debian package</a> to upgrade the Knoppix
 system you have already. Or download an updated iso image.</p>
 </div>
 <div class="section" id="method-d-nmag-virtual-machine">
-<h1><a class="toc-backref" href="#id5">Method D: Nmag Virtual Machine</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Method D: Nmag Virtual Machine</a></h1>
 <p>The Virtual machine operating system is also a Debian Linux
 installation, so you can follow the instructions for <a class="reference internal" href="#method-b-debian-package">Method B: Debian
 package</a>. Note that the default password for root is <tt class="docutils literal">nmag</tt> if you
@@ -237,7 +237,7 @@ Nmag software on the virtual machine you have already.</p>
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../rest2web.html">rest2web</a>, and <a href="../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.2/index.html
+++ b/0.2/index.html
@@ -32,10 +32,10 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
-<li><a href="http://nmag.readthedocs.io">Manual (html)</a></li>
-<li><a href="/current/manual/manual.pdf">Manual (pdf)</a></li>
-<li><a href="../download.html">Download</a></li>
+<li><a href="https:/nmag-project.github.io/nmag-doc">Manual (html)</a></li>
 <li><a href="install/index.html">installation</a></li>
+<li><a href="manual/manual.pdf">Manual (pdf)</a></li>
+<li><a href="../download.html">Download</a></li>
 
 
 
@@ -75,8 +75,9 @@
 <h1>Manual</h1>
 <p>Read the manual as</p>
 <ul class="simple">
-<li><a class="reference external" href="https://nmag.readthedocs.io/">html</a> or</li>
-<li><a class="reference external" href="/current/manual/manual.pdf">pdf</a> file.</li>
+<li><a class="reference external" href="manual/html/manual.html">html</a> with subsections or</li>
+<li><a class="reference external" href="manual/singlehtml/manual.html">single html</a> one large html file or</li>
+<li><a class="reference external" href="manual/latexpdf/manual.pdf">pdf</a> file.</li>
 </ul>
 </div>
 <div class="section" id="changelog">
@@ -172,7 +173,7 @@ which makes it easy to configure and build the nsim executable.</li>
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../rest2web.html">rest2web</a>, and <a href="../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.2/install/index.html
+++ b/0.2/install/index.html
@@ -64,40 +64,40 @@
       <div class="document" id="installation-methods">
 <h1 class="title">Installation methods</h1>
 <div class="contents topic" id="contents">
-<p class="topic-title first">Contents</p>
+<p class="topic-title">Contents</p>
 <ul class="auto-toc simple">
-<li><a class="reference internal" href="#installation-of-nmag-all-from-big-tarball" id="id5">1&nbsp;&nbsp;&nbsp;Installation of Nmag all from big tarball</a><ul class="auto-toc">
-<li><a class="reference internal" href="#what-is-it" id="id6">1.1&nbsp;&nbsp;&nbsp;What is it?</a></li>
-<li><a class="reference internal" href="#should-i-use-it" id="id7">1.2&nbsp;&nbsp;&nbsp;Should I use it?</a></li>
+<li><a class="reference internal" href="#installation-of-nmag-all-from-big-tarball" id="toc-entry-1">1&nbsp;&nbsp;&nbsp;Installation of Nmag all from big tarball</a><ul class="auto-toc">
+<li><a class="reference internal" href="#what-is-it" id="toc-entry-2">1.1&nbsp;&nbsp;&nbsp;What is it?</a></li>
+<li><a class="reference internal" href="#should-i-use-it" id="toc-entry-3">1.2&nbsp;&nbsp;&nbsp;Should I use it?</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#installation-of-nmag-core-from-small-tarball" id="id8">2&nbsp;&nbsp;&nbsp;Installation of Nmag core from small tarball</a><ul class="auto-toc">
-<li><a class="reference internal" href="#id1" id="id9">2.1&nbsp;&nbsp;&nbsp;What is it?</a></li>
-<li><a class="reference internal" href="#id2" id="id10">2.2&nbsp;&nbsp;&nbsp;Should I use it?</a></li>
+<li><a class="reference internal" href="#installation-of-nmag-core-from-small-tarball" id="toc-entry-4">2&nbsp;&nbsp;&nbsp;Installation of Nmag core from small tarball</a><ul class="auto-toc">
+<li><a class="reference internal" href="#what-is-it-1" id="toc-entry-5">2.1&nbsp;&nbsp;&nbsp;What is it?</a></li>
+<li><a class="reference internal" href="#should-i-use-it-1" id="toc-entry-6">2.2&nbsp;&nbsp;&nbsp;Should I use it?</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#installation-of-nmag-via-a-virtual-machine-vmware" id="id11">3&nbsp;&nbsp;&nbsp;Installation of Nmag via a virtual machine (VMWare)</a><ul class="auto-toc">
-<li><a class="reference internal" href="#id3" id="id12">3.1&nbsp;&nbsp;&nbsp;What is it?</a></li>
-<li><a class="reference internal" href="#id4" id="id13">3.2&nbsp;&nbsp;&nbsp;Should I use it?</a></li>
+<li><a class="reference internal" href="#installation-of-nmag-via-a-virtual-machine-vmware" id="toc-entry-7">3&nbsp;&nbsp;&nbsp;Installation of Nmag via a virtual machine (VMWare)</a><ul class="auto-toc">
+<li><a class="reference internal" href="#what-is-it-2" id="toc-entry-8">3.1&nbsp;&nbsp;&nbsp;What is it?</a></li>
+<li><a class="reference internal" href="#should-i-use-it-2" id="toc-entry-9">3.2&nbsp;&nbsp;&nbsp;Should I use it?</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="installation-of-nmag-all-from-big-tarball">
-<h1><a class="toc-backref" href="#id5">1&nbsp;&nbsp;&nbsp;Installation of Nmag all from big tarball</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">1&nbsp;&nbsp;&nbsp;Installation of Nmag all from big tarball</a></h1>
 <ul class="simple">
 <li><a class="reference external" href="install_a.html">Detailed instructions</a> and</li>
-<li><a class="reference external" href="https://github.com/fangohr/nmag-releases/raw/master/0.2/all/nmag-0.2.1.tar.gz">Available tarball</a></li>
+<li><a class="reference external" href="../download/all">Available tarballs</a></li>
 </ul>
 <div class="section" id="what-is-it">
-<h2><a class="toc-backref" href="#id6">1.1&nbsp;&nbsp;&nbsp;What is it?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-2">1.1&nbsp;&nbsp;&nbsp;What is it?</a></h2>
 <p>The compilation of Nmag all from the tarballs with names
 <tt class="docutils literal"><span class="pre">nmag-0.2.0.tar.gz</span></tt> and similar provides (nearly) all the
 required libraries and tools, including Python, Petsc, Sundials, Metis
 and others.</p>
 </div>
 <div class="section" id="should-i-use-it">
-<h2><a class="toc-backref" href="#id7">1.2&nbsp;&nbsp;&nbsp;Should I use it?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">1.2&nbsp;&nbsp;&nbsp;Should I use it?</a></h2>
 <p>Probably yes.</p>
 <p>An advantage of this installation method is that it is (more)
 independent from changing library versions: by not relying on the
@@ -113,40 +113,40 @@ is possible, but inconvenient.)</p>
 </div>
 </div>
 <div class="section" id="installation-of-nmag-core-from-small-tarball">
-<h1><a class="toc-backref" href="#id8">2&nbsp;&nbsp;&nbsp;Installation of Nmag core from small tarball</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">2&nbsp;&nbsp;&nbsp;Installation of Nmag core from small tarball</a></h1>
 <ul class="simple">
 <li><a class="reference external" href="install_b.html">Detailed instructions</a> and</li>
-<li><a class="reference external" href="https://github.com/fangohr/nmag-releases/raw/master/0.2/core/nmag-core-0.2.1.tar.gz">Available tarball</a></li>
+<li><a class="reference external" href="../download/core">Available tarballs</a></li>
 </ul>
-<div class="section" id="id1">
-<h2><a class="toc-backref" href="#id9">2.1&nbsp;&nbsp;&nbsp;What is it?</a></h2>
+<div class="section" id="what-is-it-1">
+<h2><a class="toc-backref" href="#toc-entry-5">2.1&nbsp;&nbsp;&nbsp;What is it?</a></h2>
 <p>The compilation of Nmag from the small tarballs with names
 <tt class="docutils literal"><span class="pre">nmag-0.2.0.tar.gz</span></tt> and similar requires all the
 support libraries and tools, including Python, Petsc, Sundials, Metis
 and others to be present in the system already, including their header files etc (typically provided by corresponding -dev packages).</p>
 </div>
-<div class="section" id="id2">
-<h2><a class="toc-backref" href="#id10">2.2&nbsp;&nbsp;&nbsp;Should I use it?</a></h2>
+<div class="section" id="should-i-use-it-1">
+<h2><a class="toc-backref" href="#toc-entry-6">2.2&nbsp;&nbsp;&nbsp;Should I use it?</a></h2>
 <p>An advantage of this installation method is that it allows you to use the system Python to run Nmag. This might be handy if you want to use third-party Python libraries in your Nmag scripts. This method also needs less disk space.</p>
 <p>The disadvantages include that the versions of the installed support libraries have to be compatible with Nmag's expectations.</p>
 </div>
 </div>
 <div class="section" id="installation-of-nmag-via-a-virtual-machine-vmware">
-<h1><a class="toc-backref" href="#id11">3&nbsp;&nbsp;&nbsp;Installation of Nmag via a virtual machine (VMWare)</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-7">3&nbsp;&nbsp;&nbsp;Installation of Nmag via a virtual machine (VMWare)</a></h1>
 <ul class="simple">
 <li><a class="reference external" href="vmware.html">Detailed instructions</a> and</li>
 <li><a class="reference external" href="../download/vmware">Available diskimages</a></li>
 </ul>
-<div class="section" id="id3">
-<h2><a class="toc-backref" href="#id12">3.1&nbsp;&nbsp;&nbsp;What is it?</a></h2>
+<div class="section" id="what-is-it-2">
+<h2><a class="toc-backref" href="#toc-entry-8">3.1&nbsp;&nbsp;&nbsp;What is it?</a></h2>
 <p>A disk image for a virtual machine: this allows to run a virtual linux
 system in an application on (for example) a Windows computer. Nmag can
 be used inside the virtual linux system. The disk image that we
 provide for the virtual machine contains a compiled Nmag which is
 ready to use, together with some meshing and postprocessing tools.</p>
 </div>
-<div class="section" id="id4">
-<h2><a class="toc-backref" href="#id13">3.2&nbsp;&nbsp;&nbsp;Should I use it?</a></h2>
+<div class="section" id="should-i-use-it-2">
+<h2><a class="toc-backref" href="#toc-entry-9">3.2&nbsp;&nbsp;&nbsp;Should I use it?</a></h2>
 <p>The virtual machine approach is very convenient if you want to test
 Nmag but don't want to spend much time installing it, and/or if you
 only have a Windows machine available.</p>
@@ -296,7 +296,7 @@ Abbreviations used
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../../rest2web.html">rest2web</a>, and <a href="../../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.2/install/install_b.html
+++ b/0.2/install/install_b.html
@@ -66,22 +66,22 @@
       <div class="document" id="guide-for-installing-nsim-nmag-core-from-sources-small-tarball">
 <h1 class="title">GUIDE FOR INSTALLING <tt class="docutils literal">nsim</tt>/<tt class="docutils literal">nmag</tt> core FROM SOURCES (small tarball)</h1>
 <div class="contents topic" id="table-of-contents-installing-nmag-from-small-tarball">
-<p class="topic-title first">Table of Contents Installing Nmag from small tarball</p>
+<p class="topic-title">Table of Contents Installing Nmag from small tarball</p>
 <ul class="simple">
-<li><a class="reference internal" href="#installation-requirements" id="id1">Installation requirements</a></li>
-<li><a class="reference internal" href="#download" id="id2">Download</a></li>
-<li><a class="reference internal" href="#configure" id="id3">Configure</a></li>
-<li><a class="reference internal" href="#build" id="id4">Build</a></li>
-<li><a class="reference internal" href="#testing" id="id5">Testing</a></li>
-<li><a class="reference internal" href="#special-instructions" id="id6">Special instructions</a><ul>
-<li><a class="reference internal" href="#ubuntu-11-10" id="id7">Ubuntu 11.10</a></li>
+<li><a class="reference internal" href="#installation-requirements" id="toc-entry-1">Installation requirements</a></li>
+<li><a class="reference internal" href="#download" id="toc-entry-2">Download</a></li>
+<li><a class="reference internal" href="#configure" id="toc-entry-3">Configure</a></li>
+<li><a class="reference internal" href="#build" id="toc-entry-4">Build</a></li>
+<li><a class="reference internal" href="#testing" id="toc-entry-5">Testing</a></li>
+<li><a class="reference internal" href="#special-instructions" id="toc-entry-6">Special instructions</a><ul>
+<li><a class="reference internal" href="#ubuntu-11-10" id="toc-entry-7">Ubuntu 11.10</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <p>This is installation is more complicated than the procedure involving the big tarball which is <a class="reference external" href="install_a.html">described here</a>.</p>
 <div class="section" id="installation-requirements">
-<h1><a class="toc-backref" href="#id1">Installation requirements</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">Installation requirements</a></h1>
 <p>Building <tt class="docutils literal">nmag</tt> core using the small tarball requires a number of
 libraries from the system, including:</p>
 <ul class="simple">
@@ -118,11 +118,11 @@ tarball (that brings all the libraries with it).</p>
 minutes.</p>
 </div>
 <div class="section" id="download">
-<h1><a class="toc-backref" href="#id2">Download</a></h1>
-<p>Download the tarball from <a class="reference external" href="https://github.com/fangohr/nmag-releases/raw/master/0.2/core/nmag-core-0.2.1.tar.gz">here</a>.</p>
+<h1><a class="toc-backref" href="#toc-entry-2">Download</a></h1>
+<p>Download the tarball from <a class="reference external" href="../download/core">this directory</a>.</p>
 </div>
 <div class="section" id="configure">
-<h1><a class="toc-backref" href="#id3">Configure</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Configure</a></h1>
 <p>Untar the archive in its final location:</p>
 <pre class="literal-block">
 $ tar xvzf nmag-core-0.2.0.tar.gz
@@ -141,7 +141,7 @@ $ python configure.py
 </pre>
 </div>
 <div class="section" id="build">
-<h1><a class="toc-backref" href="#id4">Build</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Build</a></h1>
 <p>Run:</p>
 <pre class="literal-block">
 $ make
@@ -161,7 +161,7 @@ $ export PATH=$PATH:`pwd`/bin
 later use of Nmag.)</p>
 </div>
 <div class="section" id="testing">
-<h1><a class="toc-backref" href="#id5">Testing</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Testing</a></h1>
 <p>To run the tests, the following steps need to be executed (from the
 installation directory in which <tt class="docutils literal">make</tt> and <tt class="docutils literal">make install</tt> where
 executed):</p>
@@ -183,9 +183,9 @@ $ make checkslow
 </pre>
 </div>
 <div class="section" id="special-instructions">
-<h1><a class="toc-backref" href="#id6">Special instructions</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-6">Special instructions</a></h1>
 <div class="section" id="ubuntu-11-10">
-<h2><a class="toc-backref" href="#id7">Ubuntu 11.10</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Ubuntu 11.10</a></h2>
 <p>The required libraries (with the exception of Sundials) can be installed using:</p>
 <pre class="literal-block">
 $ sudo aptitude install libpetsc3.1-dev libpetsc3.1  \
@@ -227,7 +227,7 @@ cd ../..
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../../rest2web.html">rest2web</a>, and <a href="../../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/0.2/install/vmware.html
+++ b/0.2/install/vmware.html
@@ -66,28 +66,28 @@
       <div class="document" id="installing-nmag-using-the-vmware-player">
 <h1 class="title">Installing Nmag using the VMware Player</h1>
 <div class="contents topic" id="contents">
-<p class="topic-title first">Contents</p>
+<p class="topic-title">Contents</p>
 <ul class="simple">
-<li><a class="reference internal" href="#introduction" id="id2">Introduction</a></li>
-<li><a class="reference internal" href="#installing-the-vmware-player" id="id3">Installing the VMware Player</a></li>
-<li><a class="reference internal" href="#downloading-and-starting-the-nmag-virtual-machine" id="id4">Downloading and starting the Nmag virtual machine</a></li>
-<li><a class="reference internal" href="#using-the-nmag-virtual-machine" id="id5">Using the Nmag virtual machine</a></li>
-<li><a class="reference internal" href="#first-steps" id="id6">First steps</a></li>
-<li><a class="reference internal" href="#using-vmware-player" id="id7">Using VMware player</a></li>
-<li><a class="reference internal" href="#frequently-asked-questions" id="id8">Frequently Asked Questions</a><ul>
-<li><a class="reference internal" href="#how-can-i-exchange-data-between-the-virtual-machine-and-the-host" id="id9">How can I exchange data between the virtual machine and the host?</a></li>
-<li><a class="reference internal" href="#how-can-i-change-the-keyboard-in-the-nmag-virtual-machine" id="id10">How can I change the keyboard in the Nmag virtual machine?</a></li>
-<li><a class="reference internal" href="#can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine" id="id11">Can I also use other VMware products with the Nmag Virtual machine?</a></li>
-<li><a class="reference internal" href="#can-i-use-other-virtual-machine-products-such-as-virtualbox" id="id12">Can I use other virtual machine products, such as VirtualBox?</a></li>
-<li><a class="reference internal" href="#i-know-ubuntu-or-debian-linux-can-i-modify-this-system" id="id13">I know Ubuntu or Debian Linux -- can I modify this system?</a></li>
-<li><a class="reference internal" href="#how-can-i-learn-more-about-linux-or-this-distribution" id="id14">How can I learn more about Linux or this distribution?</a></li>
-<li><a class="reference internal" href="#additional-software" id="id15">Additional software</a></li>
+<li><a class="reference internal" href="#introduction" id="toc-entry-1">Introduction</a></li>
+<li><a class="reference internal" href="#installing-the-vmware-player" id="toc-entry-2">Installing the VMware Player</a></li>
+<li><a class="reference internal" href="#downloading-and-starting-the-nmag-virtual-machine" id="toc-entry-3">Downloading and starting the Nmag virtual machine</a></li>
+<li><a class="reference internal" href="#using-the-nmag-virtual-machine" id="toc-entry-4">Using the Nmag virtual machine</a></li>
+<li><a class="reference internal" href="#first-steps" id="toc-entry-5">First steps</a></li>
+<li><a class="reference internal" href="#using-vmware-player" id="toc-entry-6">Using VMware player</a></li>
+<li><a class="reference internal" href="#frequently-asked-questions" id="toc-entry-7">Frequently Asked Questions</a><ul>
+<li><a class="reference internal" href="#how-can-i-exchange-data-between-the-virtual-machine-and-the-host" id="toc-entry-8">How can I exchange data between the virtual machine and the host?</a></li>
+<li><a class="reference internal" href="#how-can-i-change-the-keyboard-in-the-nmag-virtual-machine" id="toc-entry-9">How can I change the keyboard in the Nmag virtual machine?</a></li>
+<li><a class="reference internal" href="#can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine" id="toc-entry-10">Can I also use other VMware products with the Nmag Virtual machine?</a></li>
+<li><a class="reference internal" href="#can-i-use-other-virtual-machine-products-such-as-virtualbox" id="toc-entry-11">Can I use other virtual machine products, such as VirtualBox?</a></li>
+<li><a class="reference internal" href="#i-know-ubuntu-or-debian-linux-can-i-modify-this-system" id="toc-entry-12">I know Ubuntu or Debian Linux -- can I modify this system?</a></li>
+<li><a class="reference internal" href="#how-can-i-learn-more-about-linux-or-this-distribution" id="toc-entry-13">How can I learn more about Linux or this distribution?</a></li>
+<li><a class="reference internal" href="#additional-software" id="toc-entry-14">Additional software</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="introduction">
-<h1><a class="toc-backref" href="#id2">Introduction</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">Introduction</a></h1>
 <p><a class="reference external" href="http://www.vmware.com">VMware</a> is a company that provides a software that emulates a virtual
 computer. Let's assume for simplicity that we have an existing machine
 with MS Windows. This is called the host machine. One needs to install
@@ -125,7 +125,7 @@ RAM and 1 processor core. It currently needs about 7GB of disk space
 on the host machine.</p>
 </div>
 <div class="section" id="installing-the-vmware-player">
-<h1><a class="toc-backref" href="#id3">Installing the VMware Player</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Installing the VMware Player</a></h1>
 <p><a class="reference external" href="http://www.vmware.com">VMware</a> provides a multitude of different products that allow
 different degrees of virtualisation. Some of them are free and some
 have to be paid for. We try to point to exactly the right product
@@ -166,7 +166,7 @@ Machine method.</p>
 obtain the 'virtual machine' that we want to execute.</p>
 </div>
 <div class="section" id="downloading-and-starting-the-nmag-virtual-machine">
-<h1><a class="toc-backref" href="#id4">Downloading and starting the Nmag virtual machine</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Downloading and starting the Nmag virtual machine</a></h1>
 <ul class="simple">
 <li>Download the zipped Nmag virtual appliance from
 <a class="reference external" href="http://nmag.soton.ac.uk/nmag/0.2/download/vmware">this directory</a>.</li>
@@ -188,7 +188,7 @@ obtain the 'virtual machine' that we want to execute.</p>
 <p>Wait until the graphical login turns up.</p>
 </div>
 <div class="section" id="using-the-nmag-virtual-machine">
-<h1><a class="toc-backref" href="#id5">Using the Nmag virtual machine</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Using the Nmag virtual machine</a></h1>
 <p>The Nmag virtual machine is an Ubuntu64Bit 11.10 installation which should provide
 all the software required to run micromagnetic simulations with Nmag.</p>
 <p>After booting, a login screen appears. There is only one user
@@ -215,7 +215,7 @@ the commands that can be run to create a mesh, convert it, important
 it, run a simulation etc.</p>
 </div>
 <div class="section" id="first-steps">
-<h1><a class="toc-backref" href="#id6">First steps</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">First steps</a></h1>
 <ol class="arabic">
 <li><p class="first">Login as <tt class="docutils literal">nmag</tt>, password <tt class="docutils literal">nmag</tt>.</p>
 </li>
@@ -244,7 +244,7 @@ nsim sphere1.py
 </ol>
 </div>
 <div class="section" id="using-vmware-player">
-<h1><a class="toc-backref" href="#id7">Using VMware player</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-6">Using VMware player</a></h1>
 <p>The help function of the VMware Player provides a useful summary of
 how to use it.</p>
 <p>Note that you can switch to full-screen mode when pressing
@@ -253,20 +253,20 @@ pressing CTRL+ALT, or moving the mouse to the top of the screen (to
 get the VMPlayer menu).</p>
 </div>
 <div class="section" id="frequently-asked-questions">
-<h1><a class="toc-backref" href="#id8">Frequently Asked Questions</a></h1>
-<div class="contents local topic" id="id1">
+<h1><a class="toc-backref" href="#toc-entry-7">Frequently Asked Questions</a></h1>
+<div class="contents local topic" id="topic-1">
 <ul class="simple">
-<li><a class="reference internal" href="#how-can-i-exchange-data-between-the-virtual-machine-and-the-host" id="id16">How can I exchange data between the virtual machine and the host?</a></li>
-<li><a class="reference internal" href="#how-can-i-change-the-keyboard-in-the-nmag-virtual-machine" id="id17">How can I change the keyboard in the Nmag virtual machine?</a></li>
-<li><a class="reference internal" href="#can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine" id="id18">Can I also use other VMware products with the Nmag Virtual machine?</a></li>
-<li><a class="reference internal" href="#can-i-use-other-virtual-machine-products-such-as-virtualbox" id="id19">Can I use other virtual machine products, such as VirtualBox?</a></li>
-<li><a class="reference internal" href="#i-know-ubuntu-or-debian-linux-can-i-modify-this-system" id="id20">I know Ubuntu or Debian Linux -- can I modify this system?</a></li>
-<li><a class="reference internal" href="#how-can-i-learn-more-about-linux-or-this-distribution" id="id21">How can I learn more about Linux or this distribution?</a></li>
-<li><a class="reference internal" href="#additional-software" id="id22">Additional software</a></li>
+<li><a class="reference internal" href="#how-can-i-exchange-data-between-the-virtual-machine-and-the-host" id="toc-entry-15">How can I exchange data between the virtual machine and the host?</a></li>
+<li><a class="reference internal" href="#how-can-i-change-the-keyboard-in-the-nmag-virtual-machine" id="toc-entry-16">How can I change the keyboard in the Nmag virtual machine?</a></li>
+<li><a class="reference internal" href="#can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine" id="toc-entry-17">Can I also use other VMware products with the Nmag Virtual machine?</a></li>
+<li><a class="reference internal" href="#can-i-use-other-virtual-machine-products-such-as-virtualbox" id="toc-entry-18">Can I use other virtual machine products, such as VirtualBox?</a></li>
+<li><a class="reference internal" href="#i-know-ubuntu-or-debian-linux-can-i-modify-this-system" id="toc-entry-19">I know Ubuntu or Debian Linux -- can I modify this system?</a></li>
+<li><a class="reference internal" href="#how-can-i-learn-more-about-linux-or-this-distribution" id="toc-entry-20">How can I learn more about Linux or this distribution?</a></li>
+<li><a class="reference internal" href="#additional-software" id="toc-entry-21">Additional software</a></li>
 </ul>
 </div>
 <div class="section" id="how-can-i-exchange-data-between-the-virtual-machine-and-the-host">
-<h2><a class="toc-backref" href="#id16">How can I exchange data between the virtual machine and the host?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-15">How can I exchange data between the virtual machine and the host?</a></h2>
 <p>If you want to share data with your host, then</p>
 <ul>
 <li><p class="first">go to <tt class="docutils literal">Virtual <span class="pre">Machine-&gt;Settings</span></tt> (the precise name of this may vary) and look for <tt class="docutils literal">Sharing</tt></p>
@@ -284,7 +284,7 @@ data.</p>
 </ul>
 </div>
 <div class="section" id="how-can-i-change-the-keyboard-in-the-nmag-virtual-machine">
-<h2><a class="toc-backref" href="#id17">How can I change the keyboard in the Nmag virtual machine?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-16">How can I change the keyboard in the Nmag virtual machine?</a></h2>
 <p>Open a terminal (CTRL+ALT+T), then type <tt class="docutils literal">setxkbmap</tt> followed by the
 right code for the country. Typcial codes are <tt class="docutils literal">de</tt> for German,
 <tt class="docutils literal">gb</tt> for Great Britain, <tt class="docutils literal">dvorak</tt> for the Dvorak layout and <tt class="docutils literal">us</tt>
@@ -299,7 +299,7 @@ the ``Keyboard`` item. Then click on ``Layout Settings`` at the
 bottom, then click on the ``+`` (plus) symbol and take it from there. -->
 </div>
 <div class="section" id="can-i-also-use-other-vmware-products-with-the-nmag-virtual-machine">
-<h2><a class="toc-backref" href="#id18">Can I also use other VMware products with the Nmag Virtual machine?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-17">Can I also use other VMware products with the Nmag Virtual machine?</a></h2>
 <p>Yes, as far as we know. For example, if you have the VMware Work
 station or VMware Server, then these can run the Nmag virtual machine
 as well. (It may, in fact, be easier to exchange data between the host
@@ -307,7 +307,7 @@ and the virtual machine with these more powerful products, as you can
 add more shared locations.)</p>
 </div>
 <div class="section" id="can-i-use-other-virtual-machine-products-such-as-virtualbox">
-<h2><a class="toc-backref" href="#id19">Can I use other virtual machine products, such as VirtualBox?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-18">Can I use other virtual machine products, such as VirtualBox?</a></h2>
 <p>Yes, although you will not be able to use the image we provide for
 download. This will only work with VMWare. We use VMWare for
 historical reasons (it has been around for some time), but we are not
@@ -316,18 +316,18 @@ aware of any problems with other virtual machine tools.</p>
 system as Nmag installs most easily in this.</p>
 </div>
 <div class="section" id="i-know-ubuntu-or-debian-linux-can-i-modify-this-system">
-<h2><a class="toc-backref" href="#id20">I know Ubuntu or Debian Linux -- can I modify this system?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-19">I know Ubuntu or Debian Linux -- can I modify this system?</a></h2>
 <p>Of course. Once you become root, you can use <tt class="docutils literal">aptitude</tt>, <tt class="docutils literal"><span class="pre">apt-get</span></tt> and all
 other tools to configure your debian system. This is, after all, a
 normal installation (even though it is executed within a virtual
 machine).</p>
 </div>
 <div class="section" id="how-can-i-learn-more-about-linux-or-this-distribution">
-<h2><a class="toc-backref" href="#id21">How can I learn more about Linux or this distribution?</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-20">How can I learn more about Linux or this distribution?</a></h2>
 <p>Follow the <a class="reference external" href="http://www.ubuntu.com/">Ubuntu</a> tutorials.</p>
 </div>
 <div class="section" id="additional-software">
-<h2><a class="toc-backref" href="#id22">Additional software</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-21">Additional software</a></h2>
 <p>We have installed additional software on the virtual machine,
 including</p>
 <ul class="simple">
@@ -361,7 +361,7 @@ including</p>
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../../rest2web.html">rest2web</a>, and <a href="../../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/devel/index.html
+++ b/devel/index.html
@@ -108,7 +108,7 @@ $ make
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../rest2web.html">rest2web</a>, and <a href="../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/download.html
+++ b/download.html
@@ -32,10 +32,10 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
+<li><a href="https:/nmag-project.github.io/nmag-doc">Manual (html)</a></li>
 <li><a href="mailinglist.html">Mailing list</a></li>
-<li><a href="0.2/index.html">nmag 0.2</a></li>
-<li><a href="http://nmag.readthedocs.io">Manual (html)</a></li>
 <li><a href="../community/wiki/nmag">Wiki</a></li>
+<li><a href="0.2/index.html">nmag 0.2</a></li>
 <li><a href="current/manual/manual.pdf">Manual (pdf)</a></li>
 <li><a href="download.html">Download</a></li>
 
@@ -108,7 +108,7 @@ somewhat. The filenames should reveal the release number. -->
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 09:04:24 2025</strong>.</small> 
 |  Created with <a href="rest2web.html">rest2web</a>, and <a href="computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
+<li><a href="https:/nmag-project.github.io/nmag-doc">Manual (html)</a></li>
 <li><a href="mailinglist.html">Mailing list</a></li>
-<li><a href="0.2/index.html">nmag 0.2</a></li>
-<li><a href="http://nmag.readthedocs.io">Manual (html)</a></li>
 <li><a href="../community/wiki/nmag">Wiki</a></li>
+<li><a href="0.2/index.html">nmag 0.2</a></li>
 <li><a href="current/manual/manual.pdf">Manual (pdf)</a></li>
 <li><a href="download.html">Download</a></li>
 
@@ -79,10 +79,10 @@ files (of course the raw data can be extracted)</li>
 <li>(pseudo) periodic boundary conditions (&quot;macro geometry approach&quot;)</li>
 <li>Spin torque transfer (Zhang-Li model for uniform current density)</li>
 <li>Supports use of matrix compression library (HLib) for BEM</li>
-<li>extensive documentation in <a class="reference external" href="https://nmag.readthedocs.io/">html</a>
+<li>extensive documentation in <a class="reference external" href="current/manual/html/manual.html">html</a>
 and <a class="reference external" href="current/manual/manual.pdf">pdf</a>, including Tutorial</li>
-<li><a class="reference external" href="download.html">download</a> as source tarball <a class="reference external" href="https://github.com/fangohr/nmag-releases/raw/master/0.2/all/nmag-0.2.1.tar.gz">with all libraries</a>,
-or only <a class="reference external" href="https://github.com/fangohr/nmag-releases/raw/master/0.2/core/nmag-core-0.2.1.tar.gz">the core nmag code</a> (see <a class="reference external" href="0.2/install/index.html">installation</a>)</li>
+<li><a class="reference external" href="download.html">download</a> as source tarball <a class="reference external" href="current/download/all">with all libraries</a>,
+or only <a class="reference external" href="current/download/core">the core nmag code</a> (see <a class="reference external" href="current/install/index.html">installation</a>)</li>
 </ul>
 </blockquote>
 <div class="section" id="license-and-disclaimer">
@@ -169,7 +169,7 @@ The development team can be contacted at nmag@soton.ac.uk. -->
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="rest2web.html">rest2web</a>, and <a href="computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -32,10 +32,10 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
+<li><a href="https:/nmag-project.github.io/nmag-doc">Manual (html)</a></li>
 <li><a href="mailinglist.html">Mailing list</a></li>
-<li><a href="0.2/index.html">nmag 0.2</a></li>
-<li><a href="http://nmag.readthedocs.io">Manual (html)</a></li>
 <li><a href="../community/wiki/nmag">Wiki</a></li>
+<li><a href="0.2/index.html">nmag 0.2</a></li>
 <li><a href="current/manual/manual.pdf">Manual (pdf)</a></li>
 <li><a href="download.html">Download</a></li>
 
@@ -113,7 +113,7 @@ subject and the word <tt class="docutils literal">subscribe</tt> in the body of 
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="rest2web.html">rest2web</a>, and <a href="computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/newsarchive.html
+++ b/newsarchive.html
@@ -32,10 +32,10 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
+<li><a href="https:/nmag-project.github.io/nmag-doc">Manual (html)</a></li>
 <li><a href="mailinglist.html">Mailing list</a></li>
-<li><a href="0.2/index.html">nmag 0.2</a></li>
-<li><a href="http://nmag.readthedocs.io">Manual (html)</a></li>
 <li><a href="../community/wiki/nmag">Wiki</a></li>
+<li><a href="0.2/index.html">nmag 0.2</a></li>
 <li><a href="current/manual/manual.pdf">Manual (pdf)</a></li>
 <li><a href="download.html">Download</a></li>
 
@@ -165,7 +165,7 @@ outage. We believe that everything should be back to normal now.</p>
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="rest2web.html">rest2web</a>, and <a href="computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/publications.html
+++ b/publications.html
@@ -32,10 +32,10 @@
 	</li> 
         <li class="left-navheader">Pages</li>
 
+<li><a href="https:/nmag-project.github.io/nmag-doc">Manual (html)</a></li>
 <li><a href="mailinglist.html">Mailing list</a></li>
-<li><a href="0.2/index.html">nmag 0.2</a></li>
-<li><a href="http://nmag.readthedocs.io">Manual (html)</a></li>
 <li><a href="../community/wiki/nmag">Wiki</a></li>
+<li><a href="0.2/index.html">nmag 0.2</a></li>
 <li><a href="current/manual/manual.pdf">Manual (pdf)</a></li>
 <li><a href="download.html">Download</a></li>
 
@@ -123,7 +123,7 @@ Transactions on Magnetics, <strong>43</strong>, 6, 2896-2898 (2007) DOI:
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="rest2web.html">rest2web</a>, and <a href="computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/publications/index.html
+++ b/publications/index.html
@@ -77,7 +77,7 @@
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../rest2web.html">rest2web</a>, and <a href="../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>

--- a/publications/nsim2008.html
+++ b/publications/nsim2008.html
@@ -86,7 +86,7 @@ of classical field theory to computer simulations</em>. In preparation
   <!--
   Copyright &copy; Voidspace<br />Design by <a href="http://www.fuchsiashockz.co.uk">Fuchsiashockz</a> | <a href="http://validator.w3.org/check?uri=referer" title="Validate code as W3C XHTML 1.1 Strict Compliant">W3C XHTML 1.1</a> | <a href="http://jigsaw.w3.org/css-validator/check?uri=referer" title="Validate Style Sheet as W3C CSS 2.0 Compliant">W3C CSS 2.0</a>
   -->
-      <small>Page last modified <strong>Mon Dec 30 00:48:41 2019</strong>.</small> 
+      <small>Page last modified <strong>Thu Aug 14 08:48:58 2025</strong>.</small> 
 |  Created with <a href="../rest2web.html">rest2web</a>, and <a href="../computing/rstwebpage.html">reStructuredText</a> docutils.
 
 </div>


### PR DESCRIPTION
A new documentation link was added to replace the old one hosted by readthedocs.io